### PR TITLE
Add chiavdf formula updater workflow

### DIFF
--- a/.github/workflows/chiavdf.yml
+++ b/.github/workflows/chiavdf.yml
@@ -1,0 +1,54 @@
+name: Chiavdf Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "The version of chiavdf to update to"
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+env:
+  VERSION: ${{ inputs.release_version }}
+  MAC_AMD64_URL: https://github.com/Chia-Network/chiavdf/releases/download/${{ inputs.release_version }}/chiavdf-darwin-amd64.zip
+  MAC_ARM64_URL: https://github.com/Chia-Network/chiavdf/releases/download/${{ inputs.release_version }}/chiavdf-darwin-arm64.zip
+
+jobs:
+  update_formula:
+    runs-on: ubuntu-latest
+    container: ghcr.io/chia-network/build-images/ips:main
+    steps:
+      - name: Add safe Git directory
+        uses: Chia-Network/actions/git-mark-workspace-safe@main
+
+      - uses: actions/checkout@v4
+        with:
+          token: '${{ secrets.REPO_COMMIT }}'
+
+      - name: Get latest chiavdf hashes
+        run: |
+          wget "${MAC_AMD64_URL}"
+          wget "${MAC_ARM64_URL}"
+          MAC_AMD64_HASH=$(sha256sum chiavdf-darwin-amd64.zip | awk '{print $1}')
+          MAC_ARM64_HASH=$(sha256sum chiavdf-darwin-arm64.zip | awk '{print $1}')
+          echo "MAC_AMD64_HASH=${MAC_AMD64_HASH}" >> $GITHUB_ENV
+          echo "MAC_ARM64_HASH=${MAC_ARM64_HASH}" >> $GITHUB_ENV
+
+      - name: Template the chiavdf formula with updated values
+        run:
+          j2 ./templates/chiavdf.rb.j2 -o ./chiavdf.rb
+
+      - name: Set up commit signing
+        uses: Chia-Network/actions/commit-sign/gpg@main
+        with:
+          gpg_private_key: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_KEY }}
+          passphrase: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_PASSPHRASE }}
+
+      - name: Commit updated config
+        run: |
+          git status
+          ( git add chiavdf.rb && git commit -m "Updating chiavdf to version ${{ inputs.release_version }}" && git push origin main ) || true
+          git status

--- a/templates/chiavdf.rb.j2
+++ b/templates/chiavdf.rb.j2
@@ -1,0 +1,35 @@
+class Chiavdf < Formula
+  desc "VDF client binaries for hardware and software"
+  homepage "https://github.com/Chia-Network/chiavdf"
+  version "{{ VERSION }}"
+  license "Apache-2.0"
+
+  depends_on "gmp"
+
+  on_macos do
+    on_intel do
+      url "{{ MAC_AMD64_URL }}"
+      sha256 "{{ MAC_AMD64_HASH }}"
+
+      def install
+        bundle_root = Dir["chiavdf-*-macos-*"].first
+        odie "Unable to locate extracted chiavdf bundle root" if bundle_root.nil?
+        bin.install Dir["#{bundle_root}/bin/*"]
+        (libexec/"chiavdf").install Dir["#{bundle_root}/libexec/chiavdf/*"]
+        prefix.install_metafiles
+      end
+    end
+    on_arm do
+      url "{{ MAC_ARM64_URL }}"
+      sha256 "{{ MAC_ARM64_HASH }}"
+
+      def install
+        bundle_root = Dir["chiavdf-*-macos-*"].first
+        odie "Unable to locate extracted chiavdf bundle root" if bundle_root.nil?
+        bin.install Dir["#{bundle_root}/bin/*"]
+        (libexec/"chiavdf").install Dir["#{bundle_root}/libexec/chiavdf/*"]
+        prefix.install_metafiles
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a new `chiavdf` formula template that consumes darwin amd64/arm64 release archives
- declare `gmp` as a runtime Homebrew dependency for chiavdf installs
- add a dedicated workflow_dispatch updater to fetch release hashes and render `chiavdf.rb`

## Test plan
- [x] Validate `.github/workflows/chiavdf.yml` parses as YAML
- [x] Verify workflow URL/hash inputs match `chiavdf-darwin-amd64.zip` and `chiavdf-darwin-arm64.zip`
- [x] Confirm template install block extracts bundled `bin/` and `libexec/chiavdf/` layout

Made with [Cursor](https://cursor.com)